### PR TITLE
support for Tor 0.3.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ hard to build, contained no release of library itself and no simple examples. I 
 Readme is updated to reflect those changes and contains a simple example on how to use this library.
 Also I removed all data on non-android builds - there are many other easier ways to use Tor on Windows and OS/X.
 
-This fork includes latest tor built with ndk r15b.
-Included tor is built using:
+__This fork includes latest tor built with ndk r15b, using:__
 
-openssl1.1.0f 
+__openssl1.1.0f__
 
-libevent 2.0.23stable 
+__libevent 2.0.23stable__
 
-latest tor (currently 0.3.2.0 alpha-dev)
+__latest tor (currently 0.3.2.0 alpha-dev)__
+
 
 
 # What is this project?

--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ Also I removed all data on non-android builds - there are many other easier ways
 
 This fork includes latest tor built with ndk r15b.
 Included tor is built using:
+
 openssl1.1.0f 
+
 libevent 2.0.23stable 
+
 latest tor (currently 0.3.2.0 alpha-dev)
+
 
 # What is this project?
 NOTE: This project exists independently of the Tor Project.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Tor Onion Proxy Library - with tor 0.3.2.0 alpha-dev built with NDK r15b
+Tor Onion Proxy Library - with tor 0.3.1.7 built with NDK r15b
 =======================
 # What is this fork?
 This is a fork of [Thali Projects's Tor Onion Proxy Library](https://github.com/thaliproject/Tor_Onion_Proxy_Library) which was pretty outdated,
@@ -12,7 +12,7 @@ __openssl1.1.0f__
 
 __libevent 2.0.23stable__
 
-__latest tor (currently 0.3.2.0 alpha-dev)__
+__latest tor (currently 0.3.1.7)__
 
 
 # How to build aar file on Linux

--- a/README.md
+++ b/README.md
@@ -15,6 +15,33 @@ __libevent 2.0.23stable__
 __latest tor (currently 0.3.2.0 alpha-dev)__
 
 
+# How to build aar file on Linux
+
+define the ANDROID_HOME environment variable, pointing to Android Sdk and start gradle:
+
+```export ANDROID_HOME=/home/marco/Android/Sdk/
+bash gradlew assembleRelease
+```
+the resulting file is:
+
+./build/outputs/aar/ThaliOnionProxyAndroid-release.aar
+
+You can use this aar directly in your Android Studio project, see for example:
+
+https://stackoverflow.com/questions/24506648/adding-local-aar-files-to-gradle-build-using-flatdirs-is-not-working/28816265
+
+You can import a local aar file via the File>New>New Module>Import .JAR/.AAR Package option in Android Studio.
+
+Then add the following to build.gradle:
+
+```
+dependencies {
+    compile project(':ThaliOnionProxyAndroid-release')
+    compile 'org.slf4j:slf4j-api:1.7.7'
+    compile 'org.slf4j:slf4j-android:1.7.7'
+}    
+```
+
 
 # What is this project?
 NOTE: This project exists independently of the Tor Project.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Tor Onion Proxy Library - with tor 0.32 alpha-dev built with NDK r15b
+Tor Onion Proxy Library - with tor 0.3.2.0 alpha-dev built with NDK r15b
 =======================
 # What is this fork?
 This is a fork of [Thali Projects's Tor Onion Proxy Library](https://github.com/thaliproject/Tor_Onion_Proxy_Library) which was pretty outdated,
@@ -7,6 +7,10 @@ Readme is updated to reflect those changes and contains a simple example on how 
 Also I removed all data on non-android builds - there are many other easier ways to use Tor on Windows and OS/X.
 
 This fork includes latest tor built with ndk r15b.
+Included tor is built using:
+openssl1.1.0f 
+libevent 2.0.23stable 
+latest tor (currently 0.3.2.0 alpha-dev)
 
 # What is this project?
 NOTE: This project exists independently of the Tor Project.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ hard to build, contained no release of library itself and no simple examples. I 
 Readme is updated to reflect those changes and contains a simple example on how to use this library.
 Also I removed all data on non-android builds - there are many other easier ways to use Tor on Windows and OS/X.
 
+This fork includes latest tor built with ndk r15b.
+
 # What is this project?
 NOTE: This project exists independently of the Tor Project.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Tor Onion Proxy Library
+Tor Onion Proxy Library - with tor 0.32 alpha-dev built with NDK r15b
 =======================
 # What is this fork?
 This is a fork of [Thali Projects's Tor Onion Proxy Library](https://github.com/thaliproject/Tor_Onion_Proxy_Library) which was pretty outdated,

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,7 +35,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
-        versionName '0.0.5'
+        versionName '0.0.6'
         versionCode 4
         archivesBaseName = 'ThaliOnionProxyAndroid'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
         targetSdkVersion 25
         versionName '0.0.5'
         versionCode 4
-        archivesBaseName = 'ThaliOnionProxyAndroid'
+        archivesBaseName = 'MarcoTOnionProxyAndroid'
     }
     defaultConfig {
         minSdkVersion 16 // Please see the readme if you need Sdk support below 16

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
         targetSdkVersion 25
         versionName '0.0.5'
         versionCode 4
-        archivesBaseName = 'MarcoTOnionProxyAndroid'
+        archivesBaseName = 'ThaliOnionProxyAndroid'
     }
     defaultConfig {
         minSdkVersion 16 // Please see the readme if you need Sdk support below 16

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,6 +14,7 @@ See the Apache 2 License for the specific language governing permissions and lim
 buildscript {
     repositories {
         mavenCentral()
+	jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'

--- a/android/src/main/assets/torrc
+++ b/android/src/main/assets/torrc
@@ -1,7 +1,7 @@
 ControlPort auto
 CookieAuthentication 1
 DisableNetwork 0
-PidFile pid
+
 RunAsDaemon 1
 SafeSocks 1
 SOCKSPort auto

--- a/android/src/main/java/com/msopentech/thali/toronionproxy/OnionProxyContext.java
+++ b/android/src/main/java/com/msopentech/thali/toronionproxy/OnionProxyContext.java
@@ -29,6 +29,7 @@ abstract public class OnionProxyContext {
     protected final static String GEO_IP_NAME = "geoip";
     protected final static String GEO_IPV_6_NAME = "geoip6";
     protected final static String TORRC_NAME = "torrc";
+    protected final static String PID_NAME = "pid";
     protected final File workingDirectory;
     protected final File geoIpFile;
     protected final File geoIpv6File;
@@ -36,6 +37,7 @@ abstract public class OnionProxyContext {
     protected final File torExecutableFile;
     protected final File cookieFile;
     protected final File hostnameFile;
+    protected final File pidFile;
 
     public OnionProxyContext(File workingDirectory) {
         this.workingDirectory = workingDirectory;
@@ -45,6 +47,7 @@ abstract public class OnionProxyContext {
         torExecutableFile = new File(getWorkingDirectory(), getTorExecutableFileName());
         cookieFile = new File(getWorkingDirectory(), ".tor/control_auth_cookie");
         hostnameFile = new File(getWorkingDirectory(), "/" + HIDDENSERVICE_DIRECTORY_NAME + "/hostname");
+        pidFile = new File(getWorkingDirectory(), PID_NAME);
     }
 
     public void installFiles() throws IOException, InterruptedException {
@@ -144,6 +147,8 @@ abstract public class OnionProxyContext {
     public File getWorkingDirectory() {
         return workingDirectory;
     }
+
+    public File getPidFile() { return pidFile; }
 
     public void deleteAllFilesButHiddenServices() throws InterruptedException {
         // It can take a little bit for the Tor OP to detect the connection is dead and kill itself

--- a/android/src/main/java/com/msopentech/thali/toronionproxy/OnionProxyManager.java
+++ b/android/src/main/java/com/msopentech/thali/toronionproxy/OnionProxyManager.java
@@ -487,8 +487,9 @@ public abstract class OnionProxyManager {
             // For some reason the GeoIP's location can only be given as a file name, not a path and it has
             // to be in the data directory so we need to set both
             printWriter.println("DataDirectory " + onionProxyContext.getWorkingDirectory().getAbsolutePath());
-            printWriter.println("GeoIPFile " + onionProxyContext.getGeoIpFile().getName());
-            printWriter.println("GeoIPv6File " + onionProxyContext.getGeoIpv6File().getName());
+            printWriter.println("GeoIPFile " + onionProxyContext.getGeoIpFile().getAbsolutePath());
+            printWriter.println("GeoIPv6File " + onionProxyContext.getGeoIpv6File().getAbsolutePath());
+            printWriter.println("PidFile " + onionProxyContext.getPidFile().getAbsolutePath());
         } finally {
             if (printWriter != null) {
                 printWriter.close();


### PR DESCRIPTION
includes build of tor 0.3.1.7 and modifications to library to support absolute paths in configuration file (latest tor will not start if there are relative paths in configuration files).